### PR TITLE
Making classes final

### DIFF
--- a/concrete_classes/__EntityGateway.swift
+++ b/concrete_classes/__EntityGateway.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class __EntityGateway {
+final class __EntityGateway {
     
 }
 

--- a/concrete_classes/__Presenter.swift
+++ b/concrete_classes/__Presenter.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class __Presenter {
+final class __Presenter {
     
     weak var view: __View?
     let useCase: __UseCaseProtocol

--- a/concrete_classes/__UseCase.swift
+++ b/concrete_classes/__UseCase.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class __UseCase {
+final class __UseCase {
     
     weak var presenter: __Presentable?
     let entityGateway: __EntityGatewayProtocol

--- a/concrete_classes/__ViewExample.swift
+++ b/concrete_classes/__ViewExample.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class __ViewExample {
+final class __ViewExample {
     var eventHandler: __ViewEventHandler?
 }
 

--- a/concrete_classes/__Wireframe.swift
+++ b/concrete_classes/__Wireframe.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class __Wireframe {
+final class __Wireframe {
     
     func launch() {
         let view = __ViewExample()


### PR DESCRIPTION
# What 
- Making concrete classes `final` by default.

# Why
1. Having final classes seems to be more common use case than non-final.
2. [Increase performance by reducing dynamic dispatch](https://developer.apple.com/swift/blog/?id=27)